### PR TITLE
feat(config): expand ProxyJump client config workflows

### DIFF
--- a/PRD.md
+++ b/PRD.md
@@ -390,7 +390,7 @@ resemblance. Visitors to both sites will know they're from the same author.
 - [x] Equivalent `~/.ssh/config` block output
 - [x] Tests for command generation
 
-**Why tunnels first:** companion to the SSH Tunnels article/video
+**Why tunnels first:** companion to SSH Tunnels learning material
 (published 2026-03-25). Exercises all shared components (form → preview →
 copy pattern) without crypto complexity.
 

--- a/README.md
+++ b/README.md
@@ -87,10 +87,10 @@ Import behavior:
 
 ## ProxyJump Workflow
 
-The current Client Config workflow includes a video-ready ProxyJump recipe and
+The current Client Config workflow includes a practical ProxyJump recipe and
 preview helpers for bastion/private-host setups.
 
-Click the `Receita ProxyJump para vídeo` card on `/config` to load:
+Click the `Receita ProxyJump prática` card on `/config` to load:
 
 ```sshconfig
 Host bastion
@@ -251,7 +251,7 @@ npm run dev -- --host 127.0.0.1 --port 4321
 
 Open `http://127.0.0.1:4321/config/` and verify:
 
-- Clicking `Receita ProxyJump para vídeo` creates `bastion` and `prod-db`.
+- Clicking `Receita ProxyJump prática` creates `bastion` and `prod-db`.
 - The generated config matches the recipe shown in this README.
 - The visual route is `Você -> bastion -> prod-db`.
 - The `ssh`, `scp`, and `rsync` previews match the commands shown above.

--- a/README.md
+++ b/README.md
@@ -1,111 +1,329 @@
 # SSH Toolkit
 
-Toolkit SSH completo no navegador: gere chaves, endureça servidores, configure
-clientes e monte túneis. 100% client-side, zero tracking.
+Browser-based SSH toolkit for developers, students, and sysadmins. It generates
+SSH keys, hardened `sshd_config` files, client-side `~/.ssh/config` entries, and
+SSH tunnel commands.
 
-**https://sshtoolkit.otaviomiranda.com.br**
+Everything runs in the browser. There is no backend, no database, no cookies,
+no analytics, and no tracking. Sensitive SSH data should never leave the user's
+machine.
 
----
+Live site: **https://sshtoolkit.otaviomiranda.com.br**
 
-## Ferramentas
+## Tools
 
-| Ferramenta | Rota | Descricao |
-|------------|------|-----------|
-| **Tunnel Builder** | [`/tunnels`](https://sshtoolkit.otaviomiranda.com.br/tunnels/) | Comandos de tunel SSH com diagramas visuais |
-| **Server Hardening** | [`/hardening`](https://sshtoolkit.otaviomiranda.com.br/hardening/) | sshd_config endurecido com score de seguranca |
-| **Client Config** | [`/config`](https://sshtoolkit.otaviomiranda.com.br/config/) | ~/.ssh/config com ProxyJump, drag-reorder e import |
-| **Key Generator** | [`/keygen`](https://sshtoolkit.otaviomiranda.com.br/keygen/) | Chaves Ed25519/RSA via Web Crypto API |
+| Tool | Route | Purpose |
+| --- | --- | --- |
+| Tunnel Builder | [`/tunnels`](https://sshtoolkit.otaviomiranda.com.br/tunnels/) | Build SSH tunnel commands with visual diagrams. |
+| Server Hardening | [`/hardening`](https://sshtoolkit.otaviomiranda.com.br/hardening/) | Generate hardened `sshd_config` output with presets and a security score. |
+| Client Config | [`/config`](https://sshtoolkit.otaviomiranda.com.br/config/) | Build, import, preview, copy, and download `~/.ssh/config` entries. |
+| Key Generator | [`/keygen`](https://sshtoolkit.otaviomiranda.com.br/keygen/) | Generate Ed25519 and RSA key pairs with Web Crypto. |
 
-### Tunnel Builder
+## Privacy Model
 
-Monte comandos de SSH Tunnel com diagramas visuais.
+- Static Astro site. The browser is the runtime.
+- No API calls are needed for any tool.
+- No user SSH key, config, hostname, command, or generated file is sent to a
+  server by the app.
+- The generated output is shown locally and can be copied or downloaded from the
+  browser.
+- You can verify this by opening DevTools and checking the Network tab while
+  using the tools.
 
-- Local Forward (`-L`), Remote Forward (`-R`), Dynamic/SOCKS (`-D`)
-- Multiplos tuneis em um unico comando
-- Flags: `-N`, `-f`, `-C`, `ExitOnForwardFailure`, keepalive
-- Saida: comando SSH, `autossh` persistente, bloco `~/.ssh/config`
-- Diagrama visual por tunel
-- Cards de caso de uso: "Acessar banco remoto", "Expor servidor local", "Navegar via proxy"
+## Client Config
 
-### Server Hardening
+The Client Config tool builds a `~/.ssh/config` file from editable host cards.
+Each card can be collapsed, removed, reordered with drag-and-drop, copied through
+the final output, and included in a downloaded `config` file.
 
-Gere um `sshd_config` endurecido com score de seguranca.
+Supported basic fields:
 
-- Presets: Paranoico (A+), Equilibrado (A), Permissivo (B)
-- Score de seguranca 0-100 com nota A-F
-- Warnings por severidade (danger, warn, info)
-- Script de aplicacao (backup + test + restart)
-- Tooltips explicando cada diretiva
+- `Host`
+- `HostName`
+- `User`
+- `Port`
+- `IdentityFile`
+- `ProxyJump`
 
-### Client Config
+Supported advanced fields:
 
-Monte seu `~/.ssh/config` visualmente.
+- `ForwardAgent`
+- `IdentitiesOnly`
+- `AddKeysToAgent`
+- `HostKeyAlias`
+- `StrictHostKeyChecking`
+- `UserKnownHostsFile`
+- `LogLevel`
+- `IgnoreUnknown`
+- `RequestTTY`
+- `ServerAliveInterval`
+- `ServerAliveCountMax`
+- `LocalForward`
+- `RemoteForward`
+- `SendEnv`
+- `SetEnv`
+- `RemoteCommand`
+- `ExitOnForwardFailure`
 
-- CRUD de hosts com cards colapsaveis
-- ProxyJump chain visualization (Voce → bastion → destino)
-- Drag-and-drop para reordenar (a ordem importa no SSH)
-- Import: cole um config existente e edite visualmente
-- Opcoes avancadas: ForwardAgent, LocalForward, RemoteForward, etc.
+Generation behavior:
 
-### Key Generator
+- Empty values are omitted.
+- `Port 22` is omitted because it is the SSH default.
+- `ForwardAgent` and `ExitOnForwardFailure` are emitted as `yes` or `no` when
+  set.
+- `RequestTTY auto` is omitted because it is the default UI state.
+- Multiline fields emit one directive per non-empty line.
+- Unknown imported directives are preserved and emitted through `extraOptions`.
 
-Gere pares de chaves Ed25519 e RSA direto no navegador via Web Crypto API.
+Import behavior:
 
-- Ed25519 (recomendado), RSA 2048, RSA 4096
-- Download individual ou ZIP com README de instrucoes
-- Fingerprint SHA256
-- Comando `ssh-copy-id` e permissoes (`chmod`) prontos para copiar
-- Tooltips explicando cada tipo de chave
+- The import modal accepts an existing `~/.ssh/config` pasted as text.
+- `Key value` and `Key=value` syntax are both accepted.
+- Blank lines and comments are ignored.
+- Lines before the first `Host` block are ignored.
+- Known directives populate dedicated fields.
+- Unknown directives, for example `CanonicalizeHostname yes` and
+  `ConnectTimeout 10`, are preserved as extra options.
 
----
+## ProxyJump Workflow
 
-## Privacidade
+The current Client Config workflow includes a video-ready ProxyJump recipe and
+preview helpers for bastion/private-host setups.
 
-Tudo roda no seu navegador. Nenhum dado sai da sua maquina. Sem API, sem
-cookies, sem analytics. Abra o DevTools e confira a aba Network.
+Click the `Receita ProxyJump para vídeo` card on `/config` to load:
 
----
+```sshconfig
+Host bastion
+    HostName bastion.example.com
+    User deploy
+    IdentityFile ~/.ssh/id_ed25519
 
-## Stack
+Host prod-db
+    HostName 10.0.10.20
+    User deploy
+    IdentityFile ~/.ssh/id_ed25519
+    IdentitiesOnly yes
+    ProxyJump bastion
+    HostKeyAlias prod-db-private
+```
 
-- [Astro](https://astro.build/) 6.x — static site generator
-- TypeScript 5.x
-- Web Crypto API (keygen)
-- [fflate](https://github.com/101arrowz/fflate) (ZIP)
-- [Vitest](https://vitest.dev/) (testes)
-- GitHub Pages (deploy)
+Expected visible behavior:
 
----
+- Both `bastion` and `prod-db` host cards are created and opened.
+- The `prod-db` card shows the visual chain `Você -> bastion -> prod-db`.
+- The generated config keeps `IdentitiesOnly yes`, `ProxyJump bastion`, and
+  `HostKeyAlias prod-db-private`.
+- ProxyJump command previews appear for `prod-db`.
+- Copy buttons work for the final config and each generated preview.
 
-## Desenvolvimento
+Expected command previews from the recipe:
 
 ```bash
-# Requisitos: Node.js >= 22.12.0
+ssh prod-db
+ssh -J bastion -i ~/.ssh/id_ed25519 deploy@10.0.10.20
+scp -o ProxyJump=bastion -i ~/.ssh/id_ed25519 ./local-file deploy@10.0.10.20:/remote/path/
+rsync -av -e 'ssh -J bastion -i ~/.ssh/id_ed25519' ./local-file deploy@10.0.10.20:/remote/path/
+```
 
-# Instalar dependencias
+ProxyJump edge cases:
+
+- A comma-separated value such as `bastion-edge,bastion-inner` is rendered as
+  separate hops in the chain.
+- The raw `ProxyJump` value is preserved in the generated config and in direct
+  command previews.
+- `ProxyJump none` is preserved in the generated config, but it is treated as no
+  active jump for chain visualization and command previews.
+- Nested jump-host aliases are resolved in the visual chain. For example, if
+  `app` jumps to `inner` and `inner` jumps to `edge`, the route is displayed as
+  `Você -> edge -> inner -> app`.
+- Circular jump-host references are guarded and marked in the chain.
+- Command previews are hidden for wildcard, negated, comma-separated, or
+  multi-alias `Host` patterns because those are not concrete SSH targets.
+- Preview commands are practical templates. Replace placeholder paths such as
+  `./local-file` and `/remote/path/` before using `scp` or `rsync`.
+
+## Tunnel Builder
+
+The Tunnel Builder creates SSH commands, `autossh` commands, equivalent
+`~/.ssh/config` blocks, and visual diagrams for tunnel direction.
+
+Supported tunnel types:
+
+- Local forward: `-L localPort:remoteHost:remotePort`
+- Remote forward: `-R remotePort:localHost:localPort`
+- Dynamic SOCKS proxy: `-D localPort`
+
+Supported SSH options:
+
+- SSH server, optional user, optional non-default port.
+- Optional private key through `-i`.
+- Optional jump host through `-J`.
+- `-N` for no remote shell.
+- `-f` for background mode.
+- `-C` for compression.
+- `ExitOnForwardFailure=yes`.
+- `ServerAliveInterval` and `ServerAliveCountMax`.
+- Multiple tunnels in a single command.
+
+Use-case cards load examples for:
+
+- Remote database access through a local forward.
+- Exposing a local development server through a remote forward.
+- Browsing through a remote SOCKS proxy.
+
+## Server Hardening
+
+The Server Hardening tool generates an `sshd_config` and an application script.
+It is designed for review before copying the generated file to a server.
+
+Presets:
+
+- Paranoid: public-key-only defaults, root login disabled, forwarding disabled.
+- Balanced: secure general-purpose defaults with TCP forwarding enabled.
+- Permissive: lab/testing defaults with more features enabled.
+
+Config areas:
+
+- Authentication: port, root login, public key auth, password auth,
+  keyboard-interactive auth, challenge-response auth, empty passwords,
+  authentication methods, max auth tries, login grace time, and PAM.
+- Access control: `AllowUsers`, `AllowGroups`, `DenyUsers`, and `DenyGroups`.
+- Network: `ListenAddress`, `AddressFamily`, client alive settings, and
+  `UseDNS`.
+- Security: X11 forwarding, agent forwarding, TCP forwarding, stream local
+  forwarding, gateway ports, tunnel permission, user environment, user RC,
+  strict modes, session limits, startups, and log level.
+- Banners: `PrintMotd`, `PrintLastLog`, and `Banner`.
+
+Review helpers:
+
+- Security score from 0 to 100 with grade `A` through `F`.
+- Warnings for dangerous, risky, or informational choices.
+- Copy button for the generated `sshd_config`.
+- Download button for `sshd_config`.
+- Download button for `apply-sshd.sh`, which backs up the current config, runs
+  `sshd -t`, and restarts the service when the generated config is valid.
+
+## Key Generator
+
+The Key Generator creates SSH key pairs locally with the Web Crypto API.
+
+Supported key types:
+
+- Ed25519, recommended for modern systems.
+- RSA 2048 for compatibility.
+- RSA 4096 for RSA-specific setups that want a larger key.
+
+Generated output:
+
+- Private key.
+- Public key.
+- SHA256 fingerprint.
+- Equivalent `ssh-keygen` command.
+- `ssh-copy-id` install command.
+- File permission commands for `~/.ssh`, private key, public key, and
+  `authorized_keys`.
+
+Download behavior:
+
+- Public key downloads as `id_ed25519.pub` or `id_rsa.pub`.
+- Private key downloads as `id_ed25519` or `id_rsa`.
+- ZIP download includes the private key, public key, and `README.txt` setup
+  instructions.
+
+Important limitation:
+
+- Generated keys are currently not encrypted with a passphrase. Protect the
+  downloaded private key and never share it.
+
+## Local Review Checklist
+
+Use this checklist to review the current behavior before merging a PR.
+
+```bash
+git fetch origin
+git switch codex/proxyjump-client-config-stack
 npm install
-
-# Dev server
-npm run dev
-
-# Rodar testes
 npm test
+npm run build
+npm run dev -- --host 127.0.0.1 --port 4321
+```
 
-# Build
+Open `http://127.0.0.1:4321/config/` and verify:
+
+- Clicking `Receita ProxyJump para vídeo` creates `bastion` and `prod-db`.
+- The generated config matches the recipe shown in this README.
+- The visual route is `Você -> bastion -> prod-db`.
+- The `ssh`, `scp`, and `rsync` previews match the commands shown above.
+- Expanding advanced options on `prod-db` shows `IdentitiesOnly yes` and
+  `HostKeyAlias prod-db-private`.
+- Setting `ProxyJump` to `none` keeps `ProxyJump none` in the generated config
+  and hides the visual chain and previews.
+- Setting `ProxyJump` to `bastion-edge,bastion-inner` displays separate hop
+  nodes and keeps the raw comma-separated value in the direct command preview.
+- Importing a host with `IdentitiesOnly`, `AddKeysToAgent`, `LogLevel`,
+  `IgnoreUnknown`, `SendEnv`, `SetEnv`, `StrictHostKeyChecking`,
+  `UserKnownHostsFile`, and `HostKeyAlias` fills dedicated fields and
+  regenerates them as first-class directives.
+- Adding an unrelated unknown option still preserves it in generated output.
+- A wildcard host such as `*.prod` can keep `ProxyJump` in generated config, but
+  does not show command previews.
+
+Then spot-check the other routes:
+
+- `/keygen`: generate an Ed25519 key, verify fingerprint/public/private outputs,
+  copy buttons, individual downloads, ZIP download, install command, and
+  permission commands.
+- `/hardening`: switch each preset, verify score/warnings update, copy the
+  generated config, and download `sshd_config` plus `apply-sshd.sh`.
+- `/tunnels`: load each use-case card, verify the diagram, SSH command,
+  `autossh` command, equivalent config block, and copy buttons.
+
+## Out of Scope for the ProxyJump Stack
+
+The current ProxyJump Client Config stack does not implement:
+
+- `Match` blocks.
+- Bastion server hardening recipes.
+- `PermitOpen` or jump-only user generation.
+- Ansible previews.
+- SFTP previews.
+- Cloud-provider alternatives.
+- MFA, SSO, RBAC, audit/session recording, or governance workflows.
+- A site redesign.
+- Backend services.
+
+## Development
+
+Requirements:
+
+- Node.js >= 22.12.0
+
+Commands:
+
+```bash
+npm install
+npm run dev
+npm test
 npm run build
 ```
 
----
+Project stack:
 
-## Autor
+- Astro 6.x
+- TypeScript 5.x
+- Web Crypto API
+- fflate for ZIP generation
+- Vitest
+- GitHub Pages
 
-**Otavio Miranda** — [otaviomiranda.com.br](https://www.otaviomiranda.com.br)
+## Author
+
+**Otavio Miranda** - [otaviomiranda.com.br](https://www.otaviomiranda.com.br)
 
 - [YouTube](https://www.youtube.com/@otaboranern)
 - [GitHub](https://github.com/luizomf)
 
----
-
-## Licenca
+## License
 
 [MIT](./LICENSE)

--- a/src/lib/__tests__/config-generator.test.ts
+++ b/src/lib/__tests__/config-generator.test.ts
@@ -38,6 +38,22 @@ describe('generateHostBlock', () => {
     expect(result).toContain('IdentityFile ~/.ssh/id_ed25519');
   });
 
+  it('includes IdentitiesOnly yes/no when selected', () => {
+    expect(generateHostBlock(makeHost({ identitiesOnly: 'yes' }))).toContain(
+      'IdentitiesOnly yes',
+    );
+    expect(generateHostBlock(makeHost({ identitiesOnly: 'no' }))).toContain('IdentitiesOnly no');
+  });
+
+  it('includes AddKeysToAgent common and custom values', () => {
+    expect(generateHostBlock(makeHost({ addKeysToAgent: 'confirm' }))).toContain(
+      'AddKeysToAgent confirm',
+    );
+    expect(generateHostBlock(makeHost({ addKeysToAgent: '5m' }))).toContain(
+      'AddKeysToAgent 5m',
+    );
+  });
+
   it('includes ProxyJump', () => {
     const entry = makeHost({ proxyJump: 'bastion' });
     const result = generateHostBlock(entry);
@@ -52,6 +68,43 @@ describe('generateHostBlock', () => {
   it('does not include ForwardAgent when undefined', () => {
     const result = generateHostBlock(makeHost());
     expect(result).not.toContain('ForwardAgent');
+  });
+
+  it('includes logging and compatibility options', () => {
+    const entry = makeHost({
+      logLevel: 'VERBOSE',
+      ignoreUnknown: 'UseKeychain,AddKeysToAgent',
+    });
+    const result = generateHostBlock(entry);
+    expect(result).toContain('LogLevel VERBOSE');
+    expect(result).toContain('IgnoreUnknown UseKeychain,AddKeysToAgent');
+  });
+
+  it('includes repeated environment directives', () => {
+    const entry = makeHost({
+      sendEnv: ['LANG LC_*', 'TERM'],
+      setEnv: ['TERM=xterm-256color', 'APP_ENV=prod'],
+    });
+    const result = generateHostBlock(entry);
+    expect(result).toContain('SendEnv LANG LC_*');
+    expect(result).toContain('SendEnv TERM');
+    expect(result).toContain('SetEnv TERM=xterm-256color');
+    expect(result).toContain('SetEnv APP_ENV=prod');
+  });
+
+  it('includes host key policy options', () => {
+    const entry = makeHost({
+      strictHostKeyChecking: 'accept-new',
+      userKnownHostsFile: '~/.ssh/known_hosts',
+    });
+    const result = generateHostBlock(entry);
+    expect(result).toContain('StrictHostKeyChecking accept-new');
+    expect(result).toContain('UserKnownHostsFile ~/.ssh/known_hosts');
+  });
+
+  it('includes HostKeyAlias', () => {
+    const result = generateHostBlock(makeHost({ hostKeyAlias: 'prod-db-private' }));
+    expect(result).toContain('HostKeyAlias prod-db-private');
   });
 
   it('includes LocalForward entries', () => {
@@ -103,11 +156,11 @@ describe('generateHostBlock', () => {
 
   it('includes extra options', () => {
     const entry = makeHost({
-      extraOptions: { StrictHostKeyChecking: 'no', LogLevel: 'VERBOSE' },
+      extraOptions: { CanonicalizeHostname: 'yes', ConnectTimeout: '10' },
     });
     const result = generateHostBlock(entry);
-    expect(result).toContain('StrictHostKeyChecking no');
-    expect(result).toContain('LogLevel VERBOSE');
+    expect(result).toContain('CanonicalizeHostname yes');
+    expect(result).toContain('ConnectTimeout 10');
   });
 
   it('generates a full featured host', () => {

--- a/src/lib/__tests__/config-parser.test.ts
+++ b/src/lib/__tests__/config-parser.test.ts
@@ -47,6 +47,38 @@ Host bastion
     expect(result[0].proxyJump).toBe('gateway');
   });
 
+  it('parses IdentitiesOnly into a dedicated field', () => {
+    const input = `
+Host prod
+    HostName app.internal
+    IdentitiesOnly yes
+
+Host staging
+    HostName staging.example.com
+    IdentitiesOnly no
+`;
+    const result = parseConfig(input);
+    expect(result[0].identitiesOnly).toBe('yes');
+    expect(result[1].identitiesOnly).toBe('no');
+    expect(result[0].extraOptions).toBeUndefined();
+  });
+
+  it('parses AddKeysToAgent common and custom values', () => {
+    const input = `
+Host app
+    HostName app.internal
+    AddKeysToAgent confirm
+
+Host app-short
+    HostName app-short.internal
+    AddKeysToAgent 5m
+`;
+    const result = parseConfig(input);
+    expect(result[0].addKeysToAgent).toBe('confirm');
+    expect(result[1].addKeysToAgent).toBe('5m');
+    expect(result[0].extraOptions).toBeUndefined();
+  });
+
   it('parses ForwardAgent', () => {
     const input = `
 Host dev
@@ -106,17 +138,69 @@ Host tunnel
     expect(result[0].exitOnForwardFailure).toBe(true);
   });
 
+  it('parses logging and compatibility options into dedicated fields', () => {
+    const input = `
+Host verbose
+    HostName verbose.example.com
+    LogLevel DEBUG1
+    IgnoreUnknown UseKeychain,AddKeysToAgent
+`;
+    const result = parseConfig(input);
+    expect(result[0].logLevel).toBe('DEBUG1');
+    expect(result[0].ignoreUnknown).toBe('UseKeychain,AddKeysToAgent');
+    expect(result[0].extraOptions).toBeUndefined();
+  });
+
+  it('parses repeated environment directives into arrays', () => {
+    const input = `
+Host env-app
+    HostName app.internal
+    SendEnv LANG LC_*
+    SendEnv TERM
+    SetEnv TERM=xterm-256color
+    SetEnv APP_ENV=prod
+`;
+    const result = parseConfig(input);
+    expect(result[0].sendEnv).toEqual(['LANG LC_*', 'TERM']);
+    expect(result[0].setEnv).toEqual(['TERM=xterm-256color', 'APP_ENV=prod']);
+    expect(result[0].extraOptions).toBeUndefined();
+  });
+
+  it('parses host key policy options into dedicated fields', () => {
+    const input = `
+Host private-db
+    HostName 10.0.10.20
+    StrictHostKeyChecking accept-new
+    UserKnownHostsFile ~/.ssh/known_hosts
+`;
+    const result = parseConfig(input);
+    expect(result[0].strictHostKeyChecking).toBe('accept-new');
+    expect(result[0].userKnownHostsFile).toBe('~/.ssh/known_hosts');
+    expect(result[0].extraOptions).toBeUndefined();
+  });
+
+  it('parses HostKeyAlias into a dedicated field', () => {
+    const input = `
+Host private-db
+    HostName 10.0.10.20
+    HostKeyAlias prod-db-private
+`;
+    const result = parseConfig(input);
+    expect(result[0].hostKeyAlias).toBe('prod-db-private');
+    expect(result[0].extraOptions).toBeUndefined();
+  });
+
   it('stores unknown options in extraOptions', () => {
     const input = `
 Host strict
     HostName server
-    StrictHostKeyChecking no
-    LogLevel VERBOSE
+    CanonicalizeHostname yes
+    ConnectTimeout 10
 `;
     const result = parseConfig(input);
     expect(result[0].extraOptions).toEqual({
-      StrictHostKeyChecking: 'no',
-      LogLevel: 'VERBOSE',
+      CanonicalizeHostname: 'yes',
+      ConnectTimeout: '10',
     });
   });
 

--- a/src/lib/__tests__/config-preview.test.ts
+++ b/src/lib/__tests__/config-preview.test.ts
@@ -1,0 +1,139 @@
+import { describe, it, expect } from 'vitest';
+import {
+  generateProxyJumpCommandPreviews,
+  hasActiveProxyJump,
+  isConcreteHostAlias,
+  resolveProxyJumpChain,
+  splitProxyJumpValue,
+} from '../config-preview';
+import type { SshHostEntry } from '../types';
+
+function makeHost(overrides: Partial<SshHostEntry> = {}): SshHostEntry {
+  return {
+    id: '1',
+    host: 'app',
+    hostName: '10.0.10.20',
+    user: 'deploy',
+    proxyJump: 'bastion',
+    ...overrides,
+  };
+}
+
+describe('splitProxyJumpValue', () => {
+  it('splits comma-separated jump hosts into clean hops', () => {
+    expect(splitProxyJumpValue(' bastion-edge, bastion-inner,, gateway ')).toEqual([
+      'bastion-edge',
+      'bastion-inner',
+      'gateway',
+    ]);
+  });
+
+  it('treats ProxyJump none as no active jump', () => {
+    expect(splitProxyJumpValue('none')).toEqual([]);
+    expect(hasActiveProxyJump(makeHost({ proxyJump: 'none' }))).toBe(false);
+  });
+});
+
+describe('resolveProxyJumpChain', () => {
+  it('renders comma-separated ProxyJump values as ordered hops', () => {
+    const entry = makeHost({ proxyJump: 'bastion-edge,bastion-inner' });
+    expect(resolveProxyJumpChain(entry, [entry])).toEqual([
+      'Você',
+      'bastion-edge',
+      'bastion-inner',
+      'app',
+    ]);
+  });
+
+  it('includes nested jump-host routes before the referenced jump host', () => {
+    const edge = makeHost({
+      id: 'edge',
+      host: 'bastion-edge',
+      hostName: 'bastion.example.com',
+      proxyJump: undefined,
+    });
+    const inner = makeHost({
+      id: 'inner',
+      host: 'bastion-inner',
+      hostName: '10.0.0.5',
+      proxyJump: 'bastion-edge',
+    });
+    const app = makeHost({ id: 'app', host: 'app', proxyJump: 'bastion-inner' });
+
+    expect(resolveProxyJumpChain(app, [edge, inner, app])).toEqual([
+      'Você',
+      'bastion-edge',
+      'bastion-inner',
+      'app',
+    ]);
+  });
+
+  it('guards circular jump-host references', () => {
+    const edge = makeHost({ id: 'edge', host: 'edge', proxyJump: 'inner' });
+    const inner = makeHost({ id: 'inner', host: 'inner', proxyJump: 'edge' });
+    const app = makeHost({ id: 'app', host: 'app', proxyJump: 'edge' });
+
+    const chain = resolveProxyJumpChain(app, [edge, inner, app]);
+
+    expect(chain).toContain('edge (ciclo)');
+    expect(chain.at(-1)).toBe('app');
+    expect(chain.length).toBeLessThanOrEqual(6);
+  });
+});
+
+describe('isConcreteHostAlias', () => {
+  it('rejects wildcard, negated, comma-separated, and multi-alias patterns', () => {
+    expect(isConcreteHostAlias('app')).toBe(true);
+    expect(isConcreteHostAlias('*.prod')).toBe(false);
+    expect(isConcreteHostAlias('!banned')).toBe(false);
+    expect(isConcreteHostAlias('app db')).toBe(false);
+    expect(isConcreteHostAlias('app,db')).toBe(false);
+  });
+});
+
+describe('generateProxyJumpCommandPreviews', () => {
+  it('builds SSH, SCP, and rsync previews for concrete ProxyJump hosts', () => {
+    const entry = makeHost({
+      port: 2222,
+      identityFile: '~/.ssh/id_ed25519',
+      proxyJump: 'bastion-edge,bastion-inner',
+    });
+
+    expect(generateProxyJumpCommandPreviews(entry)).toEqual([
+      { kind: 'ssh-alias', command: 'ssh app' },
+      {
+        kind: 'ssh-direct',
+        command:
+          'ssh -J bastion-edge,bastion-inner -p 2222 -i ~/.ssh/id_ed25519 deploy@10.0.10.20',
+      },
+      {
+        kind: 'scp',
+        command:
+          'scp -o ProxyJump=bastion-edge,bastion-inner -P 2222 -i ~/.ssh/id_ed25519 ./local-file deploy@10.0.10.20:/remote/path/',
+      },
+      {
+        kind: 'rsync',
+        command:
+          "rsync -av -e 'ssh -J bastion-edge,bastion-inner -p 2222 -i ~/.ssh/id_ed25519' ./local-file deploy@10.0.10.20:/remote/path/",
+      },
+    ]);
+  });
+
+  it('falls back to the host alias when HostName is not set', () => {
+    const entry = makeHost({ hostName: '', user: '', identityFile: '', port: 22 });
+    const previews = generateProxyJumpCommandPreviews(entry);
+
+    expect(previews[1].command).toBe('ssh -J bastion app');
+    expect(previews[2].command).toBe(
+      'scp -o ProxyJump=bastion ./local-file app:/remote/path/',
+    );
+    expect(previews[3].command).toBe(
+      "rsync -av -e 'ssh -J bastion' ./local-file app:/remote/path/",
+    );
+  });
+
+  it('does not build misleading previews for ProxyJump none or wildcard hosts', () => {
+    expect(generateProxyJumpCommandPreviews(makeHost({ proxyJump: 'none' }))).toEqual([]);
+    expect(generateProxyJumpCommandPreviews(makeHost({ host: '*.prod' }))).toEqual([]);
+  });
+});

--- a/src/lib/config-generator.ts
+++ b/src/lib/config-generator.ts
@@ -18,10 +18,30 @@ export function generateHostBlock(entry: SshHostEntry): string {
     addLine(lines, 'Port', entry.port);
   }
   addLine(lines, 'IdentityFile', entry.identityFile);
+  addLine(lines, 'IdentitiesOnly', entry.identitiesOnly);
+  addLine(lines, 'AddKeysToAgent', entry.addKeysToAgent);
   addLine(lines, 'ProxyJump', entry.proxyJump);
 
   if (entry.forwardAgent !== undefined) {
     addLine(lines, 'ForwardAgent', entry.forwardAgent);
+  }
+
+  addLine(lines, 'HostKeyAlias', entry.hostKeyAlias);
+  addLine(lines, 'StrictHostKeyChecking', entry.strictHostKeyChecking);
+  addLine(lines, 'UserKnownHostsFile', entry.userKnownHostsFile);
+  addLine(lines, 'LogLevel', entry.logLevel);
+  addLine(lines, 'IgnoreUnknown', entry.ignoreUnknown);
+
+  if (entry.sendEnv) {
+    for (const value of entry.sendEnv) {
+      addLine(lines, 'SendEnv', value);
+    }
+  }
+
+  if (entry.setEnv) {
+    for (const value of entry.setEnv) {
+      addLine(lines, 'SetEnv', value);
+    }
   }
 
   if (entry.localForward) {

--- a/src/lib/config-parser.ts
+++ b/src/lib/config-parser.ts
@@ -4,7 +4,9 @@ const KNOWN_KEYS = new Set([
   'hostname', 'user', 'port', 'identityfile', 'proxyjump',
   'forwardagent', 'localforward', 'remoteforward', 'dynamicforward',
   'serveraliveinterval', 'serveralivecountmax', 'requesttty',
-  'remotecommand', 'exitonforwardfailure',
+  'remotecommand', 'exitonforwardfailure', 'identitiesonly',
+  'addkeystoagent', 'loglevel', 'ignoreunknown', 'sendenv', 'setenv',
+  'stricthostkeychecking', 'userknownhostsfile', 'hostkeyalias',
 ]);
 
 function parseBool(value: string): boolean {
@@ -55,11 +57,40 @@ export function parseConfig(raw: string): SshHostEntry[] {
       case 'identityfile':
         current.identityFile = value;
         break;
+      case 'identitiesonly':
+        current.identitiesOnly = value as SshHostEntry['identitiesOnly'];
+        break;
+      case 'addkeystoagent':
+        current.addKeysToAgent = value;
+        break;
       case 'proxyjump':
         current.proxyJump = value;
         break;
       case 'forwardagent':
         current.forwardAgent = parseBool(value);
+        break;
+      case 'hostkeyalias':
+        current.hostKeyAlias = value;
+        break;
+      case 'stricthostkeychecking':
+        current.strictHostKeyChecking = value;
+        break;
+      case 'userknownhostsfile':
+        current.userKnownHostsFile = value;
+        break;
+      case 'loglevel':
+        current.logLevel = value;
+        break;
+      case 'ignoreunknown':
+        current.ignoreUnknown = value;
+        break;
+      case 'sendenv':
+        current.sendEnv = current.sendEnv || [];
+        current.sendEnv.push(value);
+        break;
+      case 'setenv':
+        current.setEnv = current.setEnv || [];
+        current.setEnv.push(value);
         break;
       case 'localforward':
         current.localForward = current.localForward || [];

--- a/src/lib/config-preview.ts
+++ b/src/lib/config-preview.ts
@@ -1,0 +1,131 @@
+import type { SshHostEntry } from './types';
+
+const MAX_CHAIN_HOPS = 20;
+const LOCAL_FILE_PLACEHOLDER = './local-file';
+const REMOTE_PATH_PLACEHOLDER = '/remote/path/';
+
+export type ProxyJumpCommandKind = 'ssh-alias' | 'ssh-direct' | 'scp' | 'rsync';
+
+export interface ProxyJumpCommandPreview {
+  kind: ProxyJumpCommandKind;
+  command: string;
+}
+
+export function splitProxyJumpValue(proxyJump: string | undefined): string[] {
+  const raw = proxyJump?.trim();
+  if (!raw || raw.toLowerCase() === 'none') return [];
+
+  return raw
+    .split(',')
+    .map((hop) => hop.trim())
+    .filter((hop) => hop && hop.toLowerCase() !== 'none');
+}
+
+export function hasActiveProxyJump(entry: SshHostEntry): boolean {
+  return splitProxyJumpValue(entry.proxyJump).length > 0;
+}
+
+export function isConcreteHostAlias(host: string | undefined): boolean {
+  const value = host?.trim();
+  return Boolean(value && !/[\s!*?\[\],]/.test(value));
+}
+
+export function resolveProxyJumpChain(entry: SshHostEntry, entries: SshHostEntry[]): string[] {
+  const chain = ['Você'];
+  const nodes: string[] = [];
+  const resolving = new Set<string>();
+
+  function pushHop(hop: string): void {
+    if (nodes.length >= MAX_CHAIN_HOPS) return;
+    nodes.push(hop);
+  }
+
+  function resolveValue(proxyJump: string | undefined): void {
+    for (const hop of splitProxyJumpValue(proxyJump)) {
+      resolveHop(hop);
+    }
+  }
+
+  function resolveHop(hop: string): void {
+    if (nodes.length >= MAX_CHAIN_HOPS) return;
+
+    const key = hop.toLowerCase();
+    if (resolving.has(key)) {
+      pushHop(`${hop} (ciclo)`);
+      return;
+    }
+
+    const jumpHost = entries.find((candidate) => candidate.host.trim() === hop);
+    if (jumpHost && hasActiveProxyJump(jumpHost)) {
+      resolving.add(key);
+      resolveValue(jumpHost.proxyJump);
+      resolving.delete(key);
+    }
+
+    pushHop(hop);
+  }
+
+  resolveValue(entry.proxyJump);
+  chain.push(...nodes);
+  chain.push(entry.host.trim() || 'destino');
+
+  return chain;
+}
+
+export function generateProxyJumpCommandPreviews(entry: SshHostEntry): ProxyJumpCommandPreview[] {
+  const proxyJump = entry.proxyJump?.trim();
+  if (!proxyJump || !hasActiveProxyJump(entry) || !isConcreteHostAlias(entry.host)) return [];
+
+  const target = formatTarget(entry);
+  if (!target) return [];
+
+  return [
+    { kind: 'ssh-alias', command: `ssh ${entry.host.trim()}` },
+    { kind: 'ssh-direct', command: buildSshDirectCommand(entry, proxyJump, target) },
+    { kind: 'scp', command: buildScpCommand(entry, proxyJump, target) },
+    { kind: 'rsync', command: buildRsyncCommand(entry, proxyJump, target) },
+  ];
+}
+
+function buildSshDirectCommand(entry: SshHostEntry, proxyJump: string, target: string): string {
+  const parts = ['ssh', `-J ${proxyJump}`];
+
+  if (entry.port && entry.port !== 22) parts.push(`-p ${entry.port}`);
+  if (entry.identityFile) parts.push(`-i ${entry.identityFile}`);
+
+  parts.push(target);
+  return parts.join(' ');
+}
+
+function buildScpCommand(entry: SshHostEntry, proxyJump: string, target: string): string {
+  const parts = ['scp', `-o ProxyJump=${proxyJump}`];
+
+  if (entry.port && entry.port !== 22) parts.push(`-P ${entry.port}`);
+  if (entry.identityFile) parts.push(`-i ${entry.identityFile}`);
+
+  parts.push(LOCAL_FILE_PLACEHOLDER, `${target}:${REMOTE_PATH_PLACEHOLDER}`);
+  return parts.join(' ');
+}
+
+function buildRsyncCommand(entry: SshHostEntry, proxyJump: string, target: string): string {
+  const sshParts = ['ssh', `-J ${proxyJump}`];
+
+  if (entry.port && entry.port !== 22) sshParts.push(`-p ${entry.port}`);
+  if (entry.identityFile) sshParts.push(`-i ${entry.identityFile}`);
+
+  return [
+    'rsync',
+    '-av',
+    `-e '${sshParts.join(' ')}'`,
+    LOCAL_FILE_PLACEHOLDER,
+    `${target}:${REMOTE_PATH_PLACEHOLDER}`,
+  ].join(' ');
+}
+
+function formatTarget(entry: SshHostEntry): string {
+  const host = (entry.hostName || entry.host).trim();
+  const user = entry.user?.trim();
+
+  if (!host) return '';
+  return user ? `${user}@${host}` : host;
+}

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -52,8 +52,17 @@ export interface SshHostEntry {
   user?: string;
   port?: number;
   identityFile?: string;
+  identitiesOnly?: 'yes' | 'no';
+  addKeysToAgent?: string;
   proxyJump?: string;
   forwardAgent?: boolean;
+  hostKeyAlias?: string;
+  strictHostKeyChecking?: string;
+  userKnownHostsFile?: string;
+  logLevel?: string;
+  ignoreUnknown?: string;
+  sendEnv?: string[];
+  setEnv?: string[];
   localForward?: string[];
   remoteForward?: string[];
   dynamicForward?: string[];

--- a/src/pages/config.astro
+++ b/src/pages/config.astro
@@ -21,7 +21,7 @@ import Footer from '../components/Footer.astro';
     <div class="usecase-cards">
       <button class="usecase-card" id="usecase-bastion">
         <span class="usecase-card__icon">🏰</span>
-        <span class="usecase-card__title">Receita ProxyJump para vídeo</span>
+        <span class="usecase-card__title">Receita ProxyJump prática</span>
         <span class="usecase-card__desc">Bastion + host privado com previews</span>
       </button>
       <button class="usecase-card" id="usecase-multi-server">

--- a/src/pages/config.astro
+++ b/src/pages/config.astro
@@ -534,15 +534,15 @@ import Footer from '../components/Footer.astro';
             <input type="text" data-field="host" value="${esc(entry.host)}" placeholder="prod-server" />
           </div>
           <div class="form-group">
-            <label>HostName (IP ou domínio)</label>
+            <label>HostName (IP ou domínio) ${tip('Endereço real do servidor para este alias. Pode ser IP, domínio ou host acessível a partir do jump host.')}</label>
             <input type="text" data-field="hostName" value="${esc(entry.hostName)}" placeholder="192.168.1.10" />
           </div>
           <div class="form-group">
-            <label>Usuário</label>
+            <label>Usuário ${tip('Usuário usado por padrão ao conectar neste host. Evita digitar usuario@host em cada comando.')}</label>
             <input type="text" data-field="user" value="${esc(entry.user)}" placeholder="deploy" />
           </div>
           <div class="form-group">
-            <label>Porta</label>
+            <label>Porta ${tip('Porta SSH do servidor. O padrão é 22; informe outra porta quando o sshd estiver configurado diferente.')}</label>
             <input type="number" data-field="port" value="${entry.port || 22}" min="1" max="65535" />
           </div>
           <div class="form-group">
@@ -587,19 +587,19 @@ import Footer from '../components/Footer.astro';
             <input type="text" list="strict-host-key-options" data-field="strictHostKeyChecking" value="${esc(entry.strictHostKeyChecking)}" placeholder="accept-new" />
           </div>
           <div class="form-group">
-            <label>UserKnownHostsFile</label>
+            <label>UserKnownHostsFile ${tip('Arquivo onde o SSH grava e consulta fingerprints conhecidos. Útil para separar known_hosts por ambiente ou bastion.')}</label>
             <input type="text" data-field="userKnownHostsFile" value="${esc(entry.userKnownHostsFile)}" placeholder="~/.ssh/known_hosts" />
           </div>
           <div class="form-group">
-            <label>LogLevel</label>
+            <label>LogLevel ${tip('Nível de logs do cliente SSH. VERBOSE ajuda auditoria e troubleshooting sem chegar ao volume de DEBUG.')}</label>
             <input type="text" list="log-level-options" data-field="logLevel" value="${esc(entry.logLevel)}" placeholder="VERBOSE" />
           </div>
           <div class="form-group">
-            <label>IgnoreUnknown</label>
+            <label>IgnoreUnknown ${tip('Instrui clientes SSH a ignorarem opções desconhecidas. Ajuda em configs compartilhadas entre macOS, Linux e versões diferentes.')}</label>
             <input type="text" data-field="ignoreUnknown" value="${esc(entry.ignoreUnknown)}" placeholder="UseKeychain,AddKeysToAgent" />
           </div>
           <div class="form-group">
-            <label>RequestTTY</label>
+            <label>RequestTTY ${tip('Controla se o SSH solicita um terminal remoto. force é útil para comandos interativos; no evita TTY em automações.')}</label>
             <select data-field="requestTTY">
               <option value="auto"${entry.requestTTY === 'auto' || !entry.requestTTY ? ' selected' : ''}>auto</option>
               <option value="yes"${entry.requestTTY === 'yes' ? ' selected' : ''}>yes</option>
@@ -608,11 +608,11 @@ import Footer from '../components/Footer.astro';
             </select>
           </div>
           <div class="form-group">
-            <label>ServerAliveInterval <span class="text-muted">(s)</span></label>
+            <label>ServerAliveInterval <span class="text-muted">(s)</span> ${tip('Intervalo em segundos para o cliente enviar keepalive ao servidor. Ajuda em conexões atrás de NAT ou firewall.')}</label>
             <input type="number" data-field="serverAliveInterval" value="${entry.serverAliveInterval || ''}" min="0" placeholder="60" />
           </div>
           <div class="form-group">
-            <label>ServerAliveCountMax</label>
+            <label>ServerAliveCountMax ${tip('Número de keepalives sem resposta antes do cliente encerrar a conexão. Multiplica com ServerAliveInterval para formar o timeout.')}</label>
             <input type="number" data-field="serverAliveCountMax" value="${entry.serverAliveCountMax || ''}" min="0" placeholder="3" />
           </div>
           <div class="form-group form-group--full">
@@ -620,26 +620,26 @@ import Footer from '../components/Footer.astro';
             <textarea data-field="localForward" rows="2" placeholder="5432 localhost:5432">${(entry.localForward || []).join('\n')}</textarea>
           </div>
           <div class="form-group form-group--full">
-            <label>RemoteForward <span class="text-muted">(um por linha)</span></label>
+            <label>RemoteForward <span class="text-muted">(um por linha)</span> ${tip('Abre uma porta no servidor remoto e encaminha de volta para sua máquina. Formato comum: portaRemota hostLocal:portaLocal.')}</label>
             <textarea data-field="remoteForward" rows="2" placeholder="0.0.0.0:8080 localhost:3000">${(entry.remoteForward || []).join('\n')}</textarea>
           </div>
           <div class="form-group form-group--full">
-            <label>SendEnv <span class="text-muted">(um por linha)</span></label>
+            <label>SendEnv <span class="text-muted">(um por linha)</span> ${tip('Lista variáveis do seu ambiente local que o cliente pode enviar ao servidor, se o servidor aceitar com AcceptEnv.')}</label>
             <textarea data-field="sendEnv" rows="2" placeholder="LANG LC_*">${(entry.sendEnv || []).join('\n')}</textarea>
           </div>
           <div class="form-group form-group--full">
-            <label>SetEnv <span class="text-muted">(um por linha)</span></label>
+            <label>SetEnv <span class="text-muted">(um por linha)</span> ${tip('Define variáveis fixas para esta conexão SSH. Use formato NOME=valor, uma por linha.')}</label>
             <textarea data-field="setEnv" rows="2" placeholder="TERM=xterm-256color">${(entry.setEnv || []).join('\n')}</textarea>
           </div>
           <div class="form-group form-group--full">
-            <label>RemoteCommand</label>
+            <label>RemoteCommand ${tip('Comando executado automaticamente depois de conectar. Útil para abrir tmux, entrar em um container ou iniciar uma sessão específica.')}</label>
             <input type="text" data-field="remoteCommand" value="${esc(entry.remoteCommand)}" placeholder="tmux attach" />
           </div>
           <div class="form-group">
             <label class="toggle">
               <input type="checkbox" data-field="exitOnForwardFailure" ${entry.exitOnForwardFailure ? 'checked' : ''} />
               <span class="toggle__track"></span>
-              <span>ExitOnForwardFailure</span>
+              <span>ExitOnForwardFailure ${tip('Faz o SSH abortar quando um LocalForward, RemoteForward ou DynamicForward não consegue abrir a porta esperada.')}</span>
             </label>
           </div>
         </div>

--- a/src/pages/config.astro
+++ b/src/pages/config.astro
@@ -21,8 +21,8 @@ import Footer from '../components/Footer.astro';
     <div class="usecase-cards">
       <button class="usecase-card" id="usecase-bastion">
         <span class="usecase-card__icon">🏰</span>
-        <span class="usecase-card__title">Acessar via bastion host</span>
-        <span class="usecase-card__desc">Dois hosts com ProxyJump configurado</span>
+        <span class="usecase-card__title">Receita ProxyJump para vídeo</span>
+        <span class="usecase-card__desc">Bastion + host privado com previews</span>
       </button>
       <button class="usecase-card" id="usecase-multi-server">
         <span class="usecase-card__icon">🖥</span>
@@ -58,6 +58,31 @@ import Footer from '../components/Footer.astro';
       </div>
     </div>
   </div>
+
+  <datalist id="add-keys-to-agent-options">
+    <option value="yes"></option>
+    <option value="no"></option>
+    <option value="ask"></option>
+    <option value="confirm"></option>
+  </datalist>
+
+  <datalist id="log-level-options">
+    <option value="QUIET"></option>
+    <option value="FATAL"></option>
+    <option value="ERROR"></option>
+    <option value="INFO"></option>
+    <option value="VERBOSE"></option>
+    <option value="DEBUG1"></option>
+    <option value="DEBUG2"></option>
+    <option value="DEBUG3"></option>
+  </datalist>
+
+  <datalist id="strict-host-key-options">
+    <option value="yes"></option>
+    <option value="ask"></option>
+    <option value="accept-new"></option>
+    <option value="no"></option>
+  </datalist>
 
   <!-- Host order hint -->
   <p class="order-hint text-muted" id="order-hint" hidden>
@@ -352,9 +377,75 @@ import Footer from '../components/Footer.astro';
     color: var(--text-muted);
   }
 
+  /* Command previews */
+  .command-previews {
+    margin-top: 0.75rem;
+    padding: 0.75rem;
+    background: var(--bg-input);
+    border: 1px solid var(--border);
+    border-radius: var(--radius);
+  }
+
+  .command-previews__title {
+    margin-bottom: 0.5rem;
+    color: var(--accent);
+    font-size: 0.75rem;
+    font-weight: 700;
+    text-transform: uppercase;
+    letter-spacing: 0.05em;
+  }
+
+  .command-previews__grid {
+    display: grid;
+    gap: 0.5rem;
+  }
+
+  .command-preview {
+    display: grid;
+    grid-template-columns: minmax(6rem, 8rem) minmax(0, 1fr) auto;
+    align-items: center;
+    gap: 0.5rem;
+    padding: 0.45rem 0;
+    border-top: 1px solid var(--border);
+  }
+
+  .command-preview:first-child {
+    border-top: none;
+    padding-top: 0;
+  }
+
+  .command-preview:last-child {
+    padding-bottom: 0;
+  }
+
+  .command-preview__label {
+    color: var(--text-secondary);
+    font-size: 0.75rem;
+    text-transform: uppercase;
+    letter-spacing: 0.05em;
+  }
+
+  .command-preview code {
+    min-width: 0;
+    overflow-x: auto;
+    color: var(--text-primary);
+    font-family: var(--font-mono);
+    font-size: 0.8rem;
+    white-space: pre;
+  }
+
   @media (max-width: 640px) {
     .actions-bar {
       flex-direction: column;
+    }
+
+    .command-preview {
+      grid-template-columns: 1fr auto;
+    }
+
+    .command-preview__label,
+    .command-preview code {
+      grid-column: 1 / -1;
     }
   }
 </style>
@@ -362,15 +453,28 @@ import Footer from '../components/Footer.astro';
 <script>
   import { generateFullConfig, createEmptyHost } from '../lib/config-generator';
   import { parseConfig } from '../lib/config-parser';
+  import {
+    generateProxyJumpCommandPreviews,
+    hasActiveProxyJump,
+    resolveProxyJumpChain,
+  } from '../lib/config-preview';
   import { copyToClipboard } from '../lib/clipboard';
   import { downloadFile } from '../lib/download';
   import type { SshHostEntry } from '../lib/types';
+  import type { ProxyJumpCommandKind } from '../lib/config-preview';
 
   function tip(text: string): string {
     return `<span class="tooltip"><span class="tooltip__trigger" role="button" tabindex="0" aria-expanded="false" aria-label="Help">?</span><span class="tooltip__content" role="tooltip">${text}</span></span>`;
   }
 
   let hosts: SshHostEntry[] = [];
+
+  const previewLabels: Record<ProxyJumpCommandKind, string> = {
+    'ssh-alias': 'ssh alias',
+    'ssh-direct': 'ssh -J',
+    scp: 'scp',
+    rsync: 'rsync',
+  };
 
   const $ = <T extends HTMLElement>(id: string) => document.getElementById(id) as T;
 
@@ -394,6 +498,7 @@ import Footer from '../components/Footer.astro';
 
     updateOutput();
     updateProxyChains();
+    updateCommandPreviews();
   }
 
   function updateOutput() {
@@ -450,6 +555,7 @@ import Footer from '../components/Footer.astro';
           </div>
         </div>
         <div class="proxy-chain" data-proxy-chain="${entry.id}" hidden></div>
+        <div class="command-previews" data-command-previews="${entry.id}" hidden></div>
         <button class="advanced-toggle" data-toggle="${entry.id}">+ Opções avançadas</button>
         <div class="advanced-fields form-grid" hidden data-advanced="${entry.id}">
           <div class="form-group">
@@ -459,6 +565,38 @@ import Footer from '../components/Footer.astro';
               <option value="yes"${entry.forwardAgent === true ? ' selected' : ''}>yes</option>
               <option value="no"${entry.forwardAgent === false ? ' selected' : ''}>no</option>
             </select>
+          </div>
+          <div class="form-group">
+            <label>IdentitiesOnly ${tip('Use yes quando muitas chaves estão carregadas no agente e o servidor encerra a conexão por tentativas demais. Útil em hosts atrás de ProxyJump.')}</label>
+            <select data-field="identitiesOnly">
+              <option value=""${entry.identitiesOnly === undefined ? ' selected' : ''}>—</option>
+              <option value="yes"${entry.identitiesOnly === 'yes' ? ' selected' : ''}>yes</option>
+              <option value="no"${entry.identitiesOnly === 'no' ? ' selected' : ''}>no</option>
+            </select>
+          </div>
+          <div class="form-group">
+            <label>AddKeysToAgent ${tip('Controla se a chave entra no ssh-agent depois do uso. Valores comuns: yes, no, ask e confirm.')}</label>
+            <input type="text" list="add-keys-to-agent-options" data-field="addKeysToAgent" value="${esc(entry.addKeysToAgent)}" placeholder="confirm" />
+          </div>
+          <div class="form-group">
+            <label>HostKeyAlias ${tip('Nome usado no known_hosts. Ajuda quando redes privadas diferentes reutilizam o mesmo IP atrás de bastions.')}</label>
+            <input type="text" data-field="hostKeyAlias" value="${esc(entry.hostKeyAlias)}" placeholder="prod-db-private" />
+          </div>
+          <div class="form-group">
+            <label>StrictHostKeyChecking ${tip('Escolha avançada para política de known_hosts. Use no apenas de forma explícita e temporária.')}</label>
+            <input type="text" list="strict-host-key-options" data-field="strictHostKeyChecking" value="${esc(entry.strictHostKeyChecking)}" placeholder="accept-new" />
+          </div>
+          <div class="form-group">
+            <label>UserKnownHostsFile</label>
+            <input type="text" data-field="userKnownHostsFile" value="${esc(entry.userKnownHostsFile)}" placeholder="~/.ssh/known_hosts" />
+          </div>
+          <div class="form-group">
+            <label>LogLevel</label>
+            <input type="text" list="log-level-options" data-field="logLevel" value="${esc(entry.logLevel)}" placeholder="VERBOSE" />
+          </div>
+          <div class="form-group">
+            <label>IgnoreUnknown</label>
+            <input type="text" data-field="ignoreUnknown" value="${esc(entry.ignoreUnknown)}" placeholder="UseKeychain,AddKeysToAgent" />
           </div>
           <div class="form-group">
             <label>RequestTTY</label>
@@ -484,6 +622,14 @@ import Footer from '../components/Footer.astro';
           <div class="form-group form-group--full">
             <label>RemoteForward <span class="text-muted">(um por linha)</span></label>
             <textarea data-field="remoteForward" rows="2" placeholder="0.0.0.0:8080 localhost:3000">${(entry.remoteForward || []).join('\n')}</textarea>
+          </div>
+          <div class="form-group form-group--full">
+            <label>SendEnv <span class="text-muted">(um por linha)</span></label>
+            <textarea data-field="sendEnv" rows="2" placeholder="LANG LC_*">${(entry.sendEnv || []).join('\n')}</textarea>
+          </div>
+          <div class="form-group form-group--full">
+            <label>SetEnv <span class="text-muted">(um por linha)</span></label>
+            <textarea data-field="setEnv" rows="2" placeholder="TERM=xterm-256color">${(entry.setEnv || []).join('\n')}</textarea>
           </div>
           <div class="form-group form-group--full">
             <label>RemoteCommand</label>
@@ -535,7 +681,8 @@ import Footer from '../components/Footer.astro';
         titleEl.textContent = `Host ${entry.host || 'novo-host'}`;
         subtitleEl.textContent = [entry.user, entry.hostName].filter(Boolean).join('@');
         updateOutput();
-        if (field === 'proxyJump') updateProxyChains();
+        updateProxyChains();
+        updateCommandPreviews();
       };
       input.addEventListener('input', handler);
       input.addEventListener('change', handler);
@@ -551,12 +698,20 @@ import Footer from '../components/Footer.astro';
   ) {
     switch (field) {
       case 'host':
+        entry.host = input.value;
+        break;
       case 'hostName':
       case 'user':
       case 'identityFile':
+      case 'addKeysToAgent':
       case 'proxyJump':
+      case 'hostKeyAlias':
+      case 'strictHostKeyChecking':
+      case 'userKnownHostsFile':
+      case 'logLevel':
+      case 'ignoreUnknown':
       case 'remoteCommand':
-        (entry as Record<string, unknown>)[field] = input.value;
+        (entry as Record<string, unknown>)[field] = input.value || undefined;
         break;
       case 'port':
       case 'serverAliveInterval':
@@ -566,6 +721,11 @@ import Footer from '../components/Footer.astro';
       case 'forwardAgent':
         entry.forwardAgent = input.value === 'yes' ? true : input.value === 'no' ? false : undefined;
         break;
+      case 'identitiesOnly':
+        entry.identitiesOnly = input.value === 'yes' || input.value === 'no'
+          ? input.value
+          : undefined;
+        break;
       case 'requestTTY':
         entry.requestTTY = input.value as SshHostEntry['requestTTY'];
         break;
@@ -574,6 +734,8 @@ import Footer from '../components/Footer.astro';
         break;
       case 'localForward':
       case 'remoteForward':
+      case 'sendEnv':
+      case 'setEnv':
         (entry as Record<string, unknown>)[field] = (input as HTMLTextAreaElement).value
           .split('\n')
           .map((l: string) => l.trim())
@@ -584,38 +746,25 @@ import Footer from '../components/Footer.astro';
 
   function esc(value: string | undefined): string {
     if (!value) return '';
-    return value.replace(/"/g, '&quot;').replace(/</g, '&lt;').replace(/>/g, '&gt;');
+    return value
+      .replace(/&/g, '&amp;')
+      .replace(/"/g, '&quot;')
+      .replace(/</g, '&lt;')
+      .replace(/>/g, '&gt;');
   }
 
   // --- ProxyJump chain resolver ---
-  function resolveChain(entry: SshHostEntry): string[] {
-    const chain: string[] = ['Você'];
-    const visited = new Set<string>();
-    let jump = entry.proxyJump;
-
-    while (jump) {
-      if (visited.has(jump)) break; // circular
-      visited.add(jump);
-      chain.push(jump);
-      const jumpHost = hosts.find(h => h.host === jump);
-      jump = jumpHost?.proxyJump;
-    }
-
-    chain.push(entry.host || 'destino');
-    return chain;
-  }
-
   function updateProxyChains() {
     for (const entry of hosts) {
       const el = document.querySelector(`[data-proxy-chain="${entry.id}"]`) as HTMLElement | null;
       if (!el) continue;
 
-      if (!entry.proxyJump) {
+      if (!hasActiveProxyJump(entry)) {
         el.hidden = true;
         continue;
       }
 
-      const chain = resolveChain(entry);
+      const chain = resolveProxyJumpChain(entry, hosts);
       el.hidden = false;
       el.innerHTML = chain
         .map((node, i) => {
@@ -625,6 +774,39 @@ import Footer from '../components/Footer.astro';
             : nodeHtml;
         })
         .join(' ');
+    }
+  }
+
+  function updateCommandPreviews() {
+    for (const entry of hosts) {
+      const el = document.querySelector(
+        `[data-command-previews="${entry.id}"]`,
+      ) as HTMLElement | null;
+      if (!el) continue;
+
+      const previews = generateProxyJumpCommandPreviews(entry);
+      if (previews.length === 0) {
+        el.hidden = true;
+        el.innerHTML = '';
+        continue;
+      }
+
+      el.hidden = false;
+      el.innerHTML = `
+        <div class="command-previews__title">Previews ProxyJump</div>
+        <div class="command-previews__grid">
+          ${previews.map((preview) => {
+            const id = `preview-${entry.id}-${preview.kind}`;
+            return `
+              <div class="command-preview">
+                <span class="command-preview__label">${previewLabels[preview.kind]}</span>
+                <code id="${id}">${esc(preview.command)}</code>
+                <button class="btn btn--sm copy-btn" data-copy="${id}">Copiar</button>
+              </div>
+            `;
+          }).join('')}
+        </div>
+      `;
     }
   }
 
@@ -711,17 +893,18 @@ import Footer from '../components/Footer.astro';
   });
 
   // --- Copy ---
-  document.querySelectorAll<HTMLButtonElement>('.copy-btn').forEach((btn) => {
-    btn.addEventListener('click', async () => {
-      const targetId = btn.dataset.copy;
-      if (!targetId) return;
-      const target = $(targetId);
-      if (!target) return;
-      const success = await copyToClipboard(target.textContent || '');
-      const original = btn.textContent;
-      btn.textContent = success ? 'Copiado!' : 'Erro';
-      setTimeout(() => (btn.textContent = original), 1500);
-    });
+  document.addEventListener('click', async (event) => {
+    const btn = (event.target as HTMLElement).closest<HTMLButtonElement>('.copy-btn');
+    if (!btn) return;
+
+    const targetId = btn.dataset.copy;
+    if (!targetId) return;
+    const target = $(targetId);
+    if (!target) return;
+    const success = await copyToClipboard(target.textContent || '');
+    const original = btn.textContent;
+    btn.textContent = success ? 'Copiado!' : 'Erro';
+    setTimeout(() => (btn.textContent = original), 1500);
   });
 
   // --- Download ---
@@ -734,16 +917,18 @@ import Footer from '../components/Footer.astro';
   $<HTMLButtonElement>('usecase-bastion').addEventListener('click', () => {
     const bastion = createEmptyHost();
     bastion.host = 'bastion';
-    bastion.hostName = 'bastion.exemplo.com';
+    bastion.hostName = 'bastion.example.com';
     bastion.user = 'deploy';
     bastion.identityFile = '~/.ssh/id_ed25519';
 
     const internal = createEmptyHost();
-    internal.host = 'db-server';
-    internal.hostName = '10.0.1.50';
+    internal.host = 'prod-db';
+    internal.hostName = '10.0.10.20';
     internal.user = 'deploy';
     internal.proxyJump = 'bastion';
     internal.identityFile = '~/.ssh/id_ed25519';
+    internal.identitiesOnly = 'yes';
+    internal.hostKeyAlias = 'prod-db-private';
 
     hosts = [bastion, internal];
     render();
@@ -755,22 +940,22 @@ import Footer from '../components/Footer.astro';
   $<HTMLButtonElement>('usecase-multi-server').addEventListener('click', () => {
     const prod = createEmptyHost();
     prod.host = 'prod';
-    prod.hostName = 'prod.exemplo.com';
+    prod.hostName = 'prod.example.com';
     prod.user = 'deploy';
     prod.port = 22;
     prod.identityFile = '~/.ssh/id_ed25519';
 
     const staging = createEmptyHost();
     staging.host = 'staging';
-    staging.hostName = 'staging.exemplo.com';
+    staging.hostName = 'staging.example.com';
     staging.user = 'deploy';
     staging.port = 22;
     staging.identityFile = '~/.ssh/id_ed25519';
 
     const db = createEmptyHost();
     db.host = 'db';
-    db.hostName = '10.0.1.50';
-    db.user = 'admin';
+    db.hostName = '10.0.10.20';
+    db.user = 'deploy';
     db.proxyJump = 'prod';
     db.identityFile = '~/.ssh/id_ed25519';
 

--- a/src/pages/hardening.astro
+++ b/src/pages/hardening.astro
@@ -61,7 +61,7 @@ import Tooltip from '../components/Tooltip.astro';
     <h2 class="section__title">Autenticação</h2>
     <div class="form-grid">
       <div class="form-group">
-        <label for="port">Porta SSH</label>
+        <label for="port">Porta SSH <Tooltip text="Porta onde o sshd escuta. Trocar a 22 pode reduzir ruído de scans, mas não substitui chave forte, firewall e boas políticas." /></label>
         <input type="number" id="port" value="22" min="1" max="65535" />
       </div>
       <div class="form-group">
@@ -77,7 +77,7 @@ import Tooltip from '../components/Tooltip.astro';
         <label class="toggle">
           <input type="checkbox" id="pubkey-auth" checked />
           <span class="toggle__track"></span>
-          <span>PubkeyAuthentication</span>
+          <span>PubkeyAuthentication <Tooltip text="Permite login por chave pública. Mantenha ativado para usar chaves SSH em vez de depender de senha." /></span>
         </label>
       </div>
       <div class="form-group">
@@ -96,14 +96,14 @@ import Tooltip from '../components/Tooltip.astro';
         <input type="number" id="max-auth-tries" value="3" min="1" max="20" />
       </div>
       <div class="form-group">
-        <label for="login-grace-time">LoginGraceTime <span class="text-muted">(s)</span></label>
+        <label for="login-grace-time">LoginGraceTime <span class="text-muted">(s)</span> <Tooltip text="Tempo máximo para concluir a autenticação. Valores menores reduzem janelas abertas para tentativas lentas ou automatizadas." /></label>
         <input type="number" id="login-grace-time" value="30" min="1" />
       </div>
       <div class="form-group">
         <label class="toggle">
           <input type="checkbox" id="permit-empty-passwords" />
           <span class="toggle__track"></span>
-          <span>PermitEmptyPasswords</span>
+          <span>PermitEmptyPasswords <Tooltip text="Permite contas com senha vazia entrarem por SSH. Deve ficar desativado em praticamente todos os servidores." /></span>
         </label>
       </div>
       <div class="form-group">
@@ -125,15 +125,15 @@ import Tooltip from '../components/Tooltip.astro';
         <input type="text" id="allow-users" placeholder="deploy admin" />
       </div>
       <div class="form-group">
-        <label for="allow-groups">AllowGroups</label>
+        <label for="allow-groups">AllowGroups <Tooltip text="Apenas membros destes grupos podem logar via SSH. Útil para limitar acesso a um grupo como ssh-users." /></label>
         <input type="text" id="allow-groups" placeholder="ssh-users" />
       </div>
       <div class="form-group">
-        <label for="deny-users">DenyUsers</label>
+        <label for="deny-users">DenyUsers <Tooltip text="Bloqueia explicitamente estes usuários no SSH. Use para negar contas específicas mesmo que outras regras permitam." /></label>
         <input type="text" id="deny-users" placeholder="" />
       </div>
       <div class="form-group">
-        <label for="deny-groups">DenyGroups</label>
+        <label for="deny-groups">DenyGroups <Tooltip text="Bloqueia membros destes grupos no SSH. Ajuda a negar acesso administrativo ou contas de serviço específicas." /></label>
         <input type="text" id="deny-groups" placeholder="" />
       </div>
     </div>
@@ -144,11 +144,11 @@ import Tooltip from '../components/Tooltip.astro';
     <h2 class="section__title">Rede</h2>
     <div class="form-grid">
       <div class="form-group">
-        <label for="listen-address">ListenAddress <span class="text-muted">(opcional)</span></label>
+        <label for="listen-address">ListenAddress <span class="text-muted">(opcional)</span> <Tooltip text="Limita em quais IPs/interfaces o sshd escuta. Vazio deixa o servidor ouvir em todos os endereços disponíveis." /></label>
         <input type="text" id="listen-address" placeholder="0.0.0.0" />
       </div>
       <div class="form-group">
-        <label for="address-family">AddressFamily</label>
+        <label for="address-family">AddressFamily <Tooltip text="Controla se o sshd usa IPv4, IPv6 ou ambos. Use inet para aceitar apenas IPv4, inet6 para apenas IPv6." /></label>
         <select id="address-family">
           <option value="any" selected>any</option>
           <option value="inet">inet (IPv4)</option>
@@ -156,18 +156,18 @@ import Tooltip from '../components/Tooltip.astro';
         </select>
       </div>
       <div class="form-group">
-        <label for="client-alive-interval">ClientAliveInterval <span class="text-muted">(s)</span></label>
+        <label for="client-alive-interval">ClientAliveInterval <span class="text-muted">(s)</span> <Tooltip text="Intervalo em segundos para o servidor enviar keepalive ao cliente. Ajuda a encerrar sessões mortas." /></label>
         <input type="number" id="client-alive-interval" value="300" min="0" />
       </div>
       <div class="form-group">
-        <label for="client-alive-count">ClientAliveCountMax</label>
+        <label for="client-alive-count">ClientAliveCountMax <Tooltip text="Quantidade de keepalives sem resposta antes de derrubar a sessão. Multiplica com ClientAliveInterval para definir o timeout." /></label>
         <input type="number" id="client-alive-count" value="2" min="0" />
       </div>
       <div class="form-group">
         <label class="toggle">
           <input type="checkbox" id="use-dns" />
           <span class="toggle__track"></span>
-          <span>UseDNS</span>
+          <span>UseDNS <Tooltip text="Faz lookup reverso de DNS no login. Normalmente fica desativado para evitar atrasos e dependência de DNS." /></span>
         </label>
       </div>
     </div>
@@ -188,7 +188,7 @@ import Tooltip from '../components/Tooltip.astro';
         <label class="toggle">
           <input type="checkbox" id="agent-forwarding" />
           <span class="toggle__track"></span>
-          <span>AllowAgentForwarding</span>
+          <span>AllowAgentForwarding <Tooltip text="Permite encaminhar o ssh-agent para este servidor. Conveniente em saltos, mas arriscado em máquinas não confiáveis." /></span>
         </label>
       </div>
       <div class="form-group">
@@ -202,11 +202,11 @@ import Tooltip from '../components/Tooltip.astro';
         <label class="toggle">
           <input type="checkbox" id="stream-local-forwarding" />
           <span class="toggle__track"></span>
-          <span>AllowStreamLocalForwarding</span>
+          <span>AllowStreamLocalForwarding <Tooltip text="Permite forwarding de sockets Unix. Desative se usuários não precisam criar túneis por socket local." /></span>
         </label>
       </div>
       <div class="form-group">
-        <label for="gateway-ports">GatewayPorts</label>
+        <label for="gateway-ports">GatewayPorts <Tooltip text="Controla se túneis remotos podem escutar fora de localhost. yes pode expor portas para a rede inteira." /></label>
         <select id="gateway-ports">
           <option value="no" selected>no</option>
           <option value="clientspecified">clientspecified</option>
@@ -217,32 +217,32 @@ import Tooltip from '../components/Tooltip.astro';
         <label class="toggle">
           <input type="checkbox" id="permit-tunnel" />
           <span class="toggle__track"></span>
-          <span>PermitTunnel</span>
+          <span>PermitTunnel <Tooltip text="Permite dispositivos tun/tap via SSH, usados para VPNs. Deixe desligado se esse recurso não for necessário." /></span>
         </label>
       </div>
       <div class="form-group">
         <label class="toggle">
           <input type="checkbox" id="permit-user-env" />
           <span class="toggle__track"></span>
-          <span>PermitUserEnvironment</span>
+          <span>PermitUserEnvironment <Tooltip text="Permite que usuários definam variáveis de ambiente no SSH. Pode contornar restrições, então mantenha desativado." /></span>
         </label>
       </div>
       <div class="form-group">
         <label class="toggle">
           <input type="checkbox" id="permit-user-rc" />
           <span class="toggle__track"></span>
-          <span>PermitUserRC</span>
+          <span>PermitUserRC <Tooltip text="Executa ~/.ssh/rc após o login. Desative quando quiser reduzir hooks controlados pelo usuário." /></span>
         </label>
       </div>
       <div class="form-group">
         <label class="toggle">
           <input type="checkbox" id="strict-modes" checked />
           <span class="toggle__track"></span>
-          <span>StrictModes</span>
+          <span>StrictModes <Tooltip text="Valida permissões e dono de arquivos SSH antes do login. Mantém chaves e authorized_keys com permissões seguras." /></span>
         </label>
       </div>
       <div class="form-group">
-        <label for="max-sessions">MaxSessions</label>
+        <label for="max-sessions">MaxSessions <Tooltip text="Número máximo de sessões abertas dentro da mesma conexão SSH. Limita multiplexing e sessões simultâneas." /></label>
         <input type="number" id="max-sessions" value="5" min="1" />
       </div>
       <div class="form-group">
@@ -271,18 +271,18 @@ import Tooltip from '../components/Tooltip.astro';
         <label class="toggle">
           <input type="checkbox" id="print-motd" />
           <span class="toggle__track"></span>
-          <span>PrintMotd</span>
+          <span>PrintMotd <Tooltip text="Mostra a mensagem do dia no login. Pode ser útil para avisos, mas nem sempre é desejado em automações." /></span>
         </label>
       </div>
       <div class="form-group">
         <label class="toggle">
           <input type="checkbox" id="print-last-log" checked />
           <span class="toggle__track"></span>
-          <span>PrintLastLog</span>
+          <span>PrintLastLog <Tooltip text="Mostra o último login do usuário. Ajuda a perceber acessos inesperados." /></span>
         </label>
       </div>
       <div class="form-group form-group--full">
-        <label for="banner">Banner <span class="text-muted">(caminho do arquivo)</span></label>
+        <label for="banner">Banner <span class="text-muted">(caminho do arquivo)</span> <Tooltip text="Arquivo exibido antes da autenticação. Use para avisos legais ou mensagens institucionais curtas." /></label>
         <input type="text" id="banner" placeholder="/etc/ssh/banner.txt" />
       </div>
     </div>

--- a/src/pages/tunnels.astro
+++ b/src/pages/tunnels.astro
@@ -53,15 +53,15 @@ import Tooltip from '../components/Tooltip.astro';
     <h2 class="section__title">Conexão SSH</h2>
     <div class="form-grid">
       <div class="form-group">
-        <label for="ssh-server">Servidor SSH</label>
+        <label for="ssh-server">Servidor SSH <Tooltip text="Servidor que receberá a conexão SSH e carregará os túneis. Pode ser domínio, IP ou alias resolvido pelo seu ambiente." /></label>
         <input type="text" id="ssh-server" placeholder="seu-servidor.com" />
       </div>
       <div class="form-group">
-        <label for="ssh-user">Usuário <span class="text-muted">(opcional)</span></label>
+        <label for="ssh-user">Usuário <span class="text-muted">(opcional)</span> <Tooltip text="Usuário SSH usado para conectar no servidor. Se vazio, o SSH usa o usuário padrão do seu sistema ou do ~/.ssh/config." /></label>
         <input type="text" id="ssh-user" placeholder="deploy" />
       </div>
       <div class="form-group">
-        <label for="ssh-port">Porta <span class="text-muted">(padrão: 22)</span></label>
+        <label for="ssh-port">Porta <span class="text-muted">(padrão: 22)</span> <Tooltip text="Porta onde o sshd escuta no servidor. Mantenha 22 se não houver configuração personalizada." /></label>
         <input type="number" id="ssh-port" value="22" min="1" max="65535" />
       </div>
       <div class="form-group">
@@ -69,7 +69,7 @@ import Tooltip from '../components/Tooltip.astro';
         <input type="text" id="jump-host" placeholder="bastion" />
       </div>
       <div class="form-group">
-        <label for="identity-file">Chave Privada <span class="text-muted">(opcional)</span></label>
+        <label for="identity-file">Chave Privada <span class="text-muted">(opcional)</span> <Tooltip text="Caminho da chave privada passada com -i. Use quando esta conexão precisa de uma chave específica." /></label>
         <input type="text" id="identity-file" placeholder="~/.ssh/id_ed25519" />
       </div>
     </div>
@@ -92,7 +92,7 @@ import Tooltip from '../components/Tooltip.astro';
       <label class="toggle">
         <input type="checkbox" id="opt-compression" />
         <span class="toggle__track"></span>
-        <span>Compressão (-C)</span>
+        <span>Compressão (-C) <Tooltip text="Comprime dados no túnel. Pode ajudar em links lentos, mas costuma ser desnecessário para tráfego já comprimido." /></span>
       </label>
       <label class="toggle">
         <input type="checkbox" id="opt-exit-failure" checked />
@@ -107,7 +107,7 @@ import Tooltip from '../components/Tooltip.astro';
         <input type="number" id="alive-interval" value="60" min="0" />
       </div>
       <div class="form-group">
-        <label for="alive-count">ServerAliveCountMax</label>
+        <label for="alive-count">ServerAliveCountMax <Tooltip text="Quantidade de keepalives sem resposta antes do cliente encerrar a conexão. Junto com ServerAliveInterval define o timeout." /></label>
         <input type="number" id="alive-count" value="3" min="0" />
       </div>
     </div>
@@ -146,7 +146,7 @@ import Tooltip from '../components/Tooltip.astro';
     <div class="config-header">
       <h2 class="section__title">Equivalente ~/.ssh/config</h2>
       <div class="form-group form-group--inline">
-        <label for="host-alias">Host alias:</label>
+        <label for="host-alias">Host alias: <Tooltip text="Nome do bloco Host gerado para o ~/.ssh/config. Depois você pode conectar usando ssh este-alias." /></label>
         <input type="text" id="host-alias" value="my-tunnel" class="input--sm" />
       </div>
     </div>
@@ -372,6 +372,10 @@ import Tooltip from '../components/Tooltip.astro';
   } from '../lib/types';
   import { copyToClipboard } from '../lib/clipboard';
 
+  function tip(text: string): string {
+    return `<span class="tooltip"><span class="tooltip__trigger" role="button" tabindex="0" aria-expanded="false" aria-label="Help">?</span><span class="tooltip__content" role="tooltip">${text}</span></span>`;
+  }
+
   // --- State ---
   interface TunnelEntry {
     id: number;
@@ -400,10 +404,38 @@ import Tooltip from '../components/Tooltip.astro';
     dynamic: { listenPort: 1080, destHost: '', destPort: 0 },
   };
 
-  const typeLabels: Record<TunnelType, { listen: string; dest: string; destPort: string }> = {
-    local: { listen: 'Porta local', dest: 'Host remoto', destPort: 'Porta remota' },
-    remote: { listen: 'Porta remota', dest: 'Host local', destPort: 'Porta local' },
-    dynamic: { listen: 'Porta SOCKS', dest: '', destPort: '' },
+  const typeLabels: Record<TunnelType, {
+    listen: string;
+    listenTip: string;
+    dest: string;
+    destTip: string;
+    destPort: string;
+    destPortTip: string;
+  }> = {
+    local: {
+      listen: 'Porta local',
+      listenTip: 'Porta aberta na sua máquina. Você conecta em localhost:porta e o tráfego atravessa o SSH.',
+      dest: 'Host remoto',
+      destTip: 'Destino visto a partir do servidor SSH. Use localhost quando o serviço roda no próprio servidor.',
+      destPort: 'Porta remota',
+      destPortTip: 'Porta do serviço remoto que você quer acessar através do túnel local.',
+    },
+    remote: {
+      listen: 'Porta remota',
+      listenTip: 'Porta aberta no servidor SSH. Acessos nessa porta voltam pelo túnel para sua máquina.',
+      dest: 'Host local',
+      destTip: 'Destino visto a partir da sua máquina. Normalmente localhost para um serviço rodando localmente.',
+      destPort: 'Porta local',
+      destPortTip: 'Porta do serviço local que será exposto através do túnel remoto.',
+    },
+    dynamic: {
+      listen: 'Porta SOCKS',
+      listenTip: 'Porta local do proxy SOCKS. Configure navegador ou ferramenta para usar localhost nesta porta.',
+      dest: '',
+      destTip: '',
+      destPort: '',
+      destPortTip: '',
+    },
   };
 
   // --- Create entry ---
@@ -439,19 +471,19 @@ import Tooltip from '../components/Tooltip.astro';
       </div>
       <div class="form-grid">
         <div class="form-group">
-          <label>${labels.listen}</label>
+          <label>${labels.listen} ${tip(labels.listenTip)}</label>
           <input type="number" data-field="listenPort" value="${entry.listenPort}" min="1" max="65535" />
         </div>
         <div class="form-group">
-          <label>Bind Address <span class="text-muted">(opcional)</span></label>
+          <label>Bind Address <span class="text-muted">(opcional)</span> ${tip('Endereço onde a porta do túnel escuta. Vazio usa o padrão do SSH; 0.0.0.0 pode expor a porta para a rede.')}</label>
           <input type="text" data-field="bindAddr" value="${entry.bindAddr}" placeholder="localhost" />
         </div>
         <div class="form-group" ${showDest ? '' : 'hidden'}>
-          <label>${labels.dest}</label>
+          <label>${labels.dest} ${tip(labels.destTip)}</label>
           <input type="text" data-field="destHost" value="${entry.destHost}" />
         </div>
         <div class="form-group" ${showDest ? '' : 'hidden'}>
-          <label>${labels.destPort}</label>
+          <label>${labels.destPort} ${tip(labels.destPortTip)}</label>
           <input type="number" data-field="destPort" value="${entry.destPort}" min="1" max="65535" />
         </div>
       </div>


### PR DESCRIPTION
## Summary

- Add dedicated Client Config support for advanced SSH client directives: `IdentitiesOnly`, `AddKeysToAgent`, `LogLevel`, `IgnoreUnknown`, `SendEnv`, `SetEnv`, `StrictHostKeyChecking`, `UserKnownHostsFile`, and `HostKeyAlias`.
- Add tested ProxyJump helpers for comma-separated hop chains, nested jump aliases, circular-reference guards, and `ssh`/`scp`/`rsync` preview commands.
- Update the `/config` UI with advanced controls, copyable ProxyJump command previews, and a practical bastion/private-host recipe using example-only values.
- Generalize docs and UI wording so the recipe is framed as a reusable toolkit workflow.

## Verification

- `npm test`
- `npm run build`
- Browser check: opened `/config`, loaded the ProxyJump recipe, verified the visual chain, generated config, command previews, advanced fields, and no browser console errors.

References #17.

Closes #18.
Closes #19.
Closes #20.
Closes #21.
Closes #22.
Closes #23.
Closes #24.
Closes #25.
Closes #26.
Closes #27.
